### PR TITLE
Extract text from common document types

### DIFF
--- a/SharePointClient.cs
+++ b/SharePointClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -7,6 +8,9 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using UglyToad.PdfPig;
 
 namespace SharePointCrawler;
 
@@ -273,6 +277,29 @@ public class SharePointClient : IDisposable
     /// <param name="doc">The document information to send.</param>
     protected virtual async Task SendToExternalApiAsync(DocumentInfo doc)
     {
+        string? textContent = null;
+        var extension = Path.GetExtension(doc.Name).ToLowerInvariant();
+
+        try
+        {
+            switch (extension)
+            {
+                case ".txt":
+                case ".md":
+                    textContent = Encoding.UTF8.GetString(doc.Data);
+                    break;
+                case ".pdf":
+                    textContent = ExtractPdfText(doc.Data);
+                    break;
+                case ".docx":
+                    textContent = ExtractWordText(doc.Data);
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to extract text for {doc.Name}: {ex.Message}");
+        }
 
         var payload = new RagIngestDocument
         {
@@ -298,10 +325,10 @@ public class SharePointClient : IDisposable
             AssociationIds = ExtractKeywords(doc, "Association"),
 
             FileName = doc.Name,
-            ContentBytes = Convert.ToBase64String(doc.Data),
-            
+            TextContent = textContent,
+            ContentBytes = textContent is null ? Convert.ToBase64String(doc.Data) : null,
+
         };
-        var ctn = Convert.FromBase64String(payload.ContentBytes);
 
         using var httpClient = new HttpClient();
         var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower });
@@ -313,10 +340,39 @@ public class SharePointClient : IDisposable
 
             if (!response.IsSuccessStatusCode)
                 Console.WriteLine(response.Content.ToString());
-        }catch(Exception ex)
-        { 
-            Console.WriteLine(ex.ToString()); 
         }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.ToString());
+        }
+    }
+
+    private static string ExtractPdfText(byte[] data)
+    {
+        using var ms = new MemoryStream(data);
+        using var document = PdfDocument.Open(ms);
+        var sb = new StringBuilder();
+        foreach (var page in document.GetPages())
+        {
+            sb.AppendLine(page.Text);
+        }
+        return sb.ToString();
+    }
+
+    private static string ExtractWordText(byte[] data)
+    {
+        using var ms = new MemoryStream(data);
+        using var doc = WordprocessingDocument.Open(ms, false);
+        var sb = new StringBuilder();
+        var body = doc.MainDocumentPart?.Document.Body;
+        if (body != null)
+        {
+            foreach (var text in body.Descendants<Text>())
+            {
+                sb.Append(text.Text);
+            }
+        }
+        return sb.ToString();
     }
     private List<string> ExtractKeywords(DocumentInfo doc, string field)
     {

--- a/SharePointCrawler.csproj
+++ b/SharePointCrawler.csproj
@@ -7,4 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- extract text from `.txt`, `.md`, `.pdf` and `.docx` files in `SendToExternalApiAsync`
- populate `TextContent` instead of `ContentBytes` when text is available
- add PDF and Word text extraction libraries

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e6d74204832484c32ce9c207cb8a