### PR TITLE
Enhance document cleaning and metadata extraction

### DIFF
--- a/RagIngestDocument.cs
+++ b/RagIngestDocument.cs
@@ -35,6 +35,7 @@ namespace SharePointCrawler
         public string? FileName { get; set; }
         public string? ContentBytes { get; set; }
         public string? TextContent { get; set; }
+        public string? Summary { get; set; }
 
         public int ChunkSize { get; set; } = 1400;
         public int ChunkOverlap { get; set; } = 300;


### PR DESCRIPTION
## Summary
- Clean extracted text to remove headers, footers, page numbers, and other boilerplate before ingesting.
- Derive title, category, keywords, and optional summary from document content and skip short documents.
- Extend ingest payload with summary and update Excel text extraction.

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a92a8abc988324a2370e512c29db2d