### PR TITLE
Add token-based chunking and selective crawl options

### DIFF
--- a/CrawlerOptions.cs
+++ b/CrawlerOptions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace SharePointCrawler;
+
+/// <summary>
+/// Options controlling how the crawler processes and posts documents.
+/// </summary>
+public class CrawlerOptions
+{
+    public string Mode { get; set; } = "all";
+    public HashSet<string>? Titles { get; set; }
+        = null; // Populated when mode == titles
+    public string Collection { get; set; }
+        = Environment.GetEnvironmentVariable("CRAWLER_COLLECTION") ?? "docs_v2";
+    public int ChunkSizeTokens { get; set; } = 350;
+    public int ChunkOverlapTokens { get; set; } = 80;
+    public int? MaxDocs { get; set; }
+        = null; // Optional limiter for testing
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,32 +1,28 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
 namespace SharePointCrawler;
 
-/// <summary>
-/// The entry point for the SharePoint crawler.  This console application
-/// accepts a SharePoint site URL, the server relative URL of the document
-/// library or folder to crawl and a set of Windows credentials.  It then
-/// instantiates a <see cref="SharePointClient"/> and iterates through all
-/// documents returned by the SharePoint REST API, printing basic
-/// information about each file to the console.  The credentials should
-/// correspond to a user account with permission to read from the target
-/// library.
-/// </summary>
 public static class Program
 {
     public static async Task Main(string[] args)
     {
         if (args.Length < 4)
         {
-            Console.WriteLine("Usage: dotnet run <siteUrl> <libraryRelativeUrl> <username> <password> [domain]");
+            Console.WriteLine("Usage: dotnet run <siteUrl> <libraryRelativeUrl> <username> <password> [domain] [options]");
             Console.WriteLine();
-            Console.WriteLine("siteUrl:           The base URL of your SharePoint site (e.g. https://server/sites/DevSite)");
-            Console.WriteLine("libraryRelativeUrl: Server relative URL of the document library or folder to crawl (e.g. /Shared Documents)");
-            Console.WriteLine("username:          The user name to authenticate with");
-            Console.WriteLine("password:          The password for the user");
-            Console.WriteLine("domain (optional): The Active Directory domain (on‑prem only)");
+            Console.WriteLine("Options:");
+            Console.WriteLine("  --mode <all|titles>           Crawl mode (default all)");
+            Console.WriteLine("  --titles-file <path>          File containing titles to ingest");
+            Console.WriteLine("  --titles \"TitleA;TitleB\"   Semicolon separated titles");
+            Console.WriteLine("  --collection <name>          Target embedding collection (default docs_v2)");
+            Console.WriteLine("  --chunk-size-tokens <num>    Tokens per chunk (default 350)");
+            Console.WriteLine("  --chunk-overlap-tokens <num> Token overlap (default 80)");
+            Console.WriteLine("  --max-docs <num>             Limit number of documents (optional)");
             return;
         }
 
@@ -34,18 +30,109 @@ public static class Program
         var libraryRelativeUrl = $"{siteUrl}/_api/web/GetFolderByServerRelativeUrl('{args[1]}')?$expand=Folders,Files";
         var username = args[2];
         var password = args[3];
-        var domain = args.Length > 4 ? args[4] : string.Empty;
+        string domain = string.Empty;
+        var index = 4;
+        if (args.Length > 4 && !args[4].StartsWith("--"))
+        {
+            domain = args[4];
+            index = 5;
+        }
 
-        // Create the credential.  If a domain is supplied we include it;
-        // otherwise we assume a local machine account.
+        var options = new CrawlerOptions();
+        string? titlesFile = null;
+        string? titlesInline = null;
+
+        for (; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--mode":
+                    options.Mode = index + 1 < args.Length ? args[++index] : options.Mode;
+                    break;
+                case "--titles-file":
+                    titlesFile = index + 1 < args.Length ? args[++index] : null;
+                    break;
+                case "--titles":
+                    titlesInline = index + 1 < args.Length ? args[++index] : null;
+                    break;
+                case "--collection":
+                    options.Collection = index + 1 < args.Length ? args[++index] : options.Collection;
+                    break;
+                case "--chunk-size-tokens":
+                    if (index + 1 < args.Length && int.TryParse(args[++index], out var cst))
+                        options.ChunkSizeTokens = cst;
+                    break;
+                case "--chunk-overlap-tokens":
+                    if (index + 1 < args.Length && int.TryParse(args[++index], out var cot))
+                        options.ChunkOverlapTokens = cot;
+                    break;
+                case "--max-docs":
+                    if (index + 1 < args.Length && int.TryParse(args[++index], out var md))
+                        options.MaxDocs = md;
+                    break;
+                default:
+                    Console.WriteLine($"Unknown argument {args[index]}");
+                    break;
+            }
+        }
+
+        HashSet<string>? titleSet = null;
+        HashSet<string> matchedTitles = new(StringComparer.OrdinalIgnoreCase);
+        if (options.Mode.Equals("titles", StringComparison.OrdinalIgnoreCase))
+        {
+            titleSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrWhiteSpace(titlesFile) && File.Exists(titlesFile))
+            {
+                foreach (var line in File.ReadAllLines(titlesFile))
+                {
+                    if (!string.IsNullOrWhiteSpace(line))
+                        titleSet.Add(line.Trim());
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(titlesInline))
+            {
+                foreach (var part in titlesInline.Split(';'))
+                {
+                    if (!string.IsNullOrWhiteSpace(part))
+                        titleSet.Add(part.Trim());
+                }
+            }
+            options.Titles = titleSet;
+        }
+
         NetworkCredential credential = new(username, password, domain);
-
         ConsoleWindow.Initialize();
 
-        using var client = new SharePointClient(siteUrl, credential);
-        await foreach (var doc in client.GetDocumentsAsync(libraryRelativeUrl))
+        Func<DocumentInfo, bool>? filter = null;
+        if (titleSet != null)
+        {
+            filter = doc =>
+            {
+                var docTitle = doc.Metadata.TryGetValue("Title", out var t)
+                    ? t?.ToString()?.Trim()
+                    : Path.GetFileNameWithoutExtension(doc.Name);
+                if (docTitle != null && titleSet.Contains(docTitle))
+                {
+                    matchedTitles.Add(docTitle);
+                    return true;
+                }
+                return false;
+            };
+        }
+
+        using var client = new SharePointClient(siteUrl, credential, options, filter);
+        await foreach (var _ in client.GetDocumentsAsync(libraryRelativeUrl))
         {
             // Processing feedback is handled by SharePointClient via ConsoleWindow.
+        }
+
+        Console.WriteLine($"Docs scanned: {client.DocsScanned}, selected: {client.DocsSelected}, chunks: {client.ChunksProduced}, collection: {client.Collection}");
+        if (titleSet != null)
+        {
+            foreach (var t in titleSet.Except(matchedTitles))
+            {
+                Console.WriteLine($"Title not matched: {t}");
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -42,18 +42,22 @@ You can override the protected `SendToExternalApiAsync` method in a derived clas
 
 ### Program
 
-The console host expects the following command‑line arguments:
+The console host accepts positional credentials followed by optional switches:
 
 ```text
-dotnet run <siteUrl> <libraryRelativeUrl> <username> <password> [domain]
+dotnet run <siteUrl> <libraryRelativeUrl> <username> <password> [domain] [options]
 ```
 
-* `siteUrl` – The base URL of your SharePoint site (e.g. `https://server/sites/DevSite`).
-* `libraryRelativeUrl` – The server‑relative path of the library or folder to crawl (e.g. `/Shared Documents`).
-* `username`/`password` – Credentials for a user with read access to the library.
-* `domain` – Optional Active Directory domain for on‑premises environments.
+**Options**
 
-The program constructs a `NetworkCredential` from the supplied account and iterates through all files returned by the crawler, printing basic information (name, URL and size).  Modify the loop to implement your own business logic.
+* `--mode <all|titles>` – crawl entire library or only documents whose titles match a provided list.
+* `--titles-file <path>` – newline‑separated file of titles used when `--mode titles` is selected.
+* `--titles "TitleA;TitleB"` – inline semicolon separated titles.
+* `--collection <name>` – AdamPY embedding collection (defaults to `docs_v2` or `CRAWLER_COLLECTION` env var).
+* `--chunk-size-tokens <n>` / `--chunk-overlap-tokens <n>` – token based chunk sizing (defaults 350/80).
+* `--max-docs <n>` – optionally limit number of documents for testing.
+
+The program constructs a `NetworkCredential` from the supplied account and iterates through all files returned by the crawler.  Each document is tokenized into heading‑aware chunks before being posted to the local AdamPY embedding API.
 
 ## Building and running
 

--- a/Tokenizer.cs
+++ b/Tokenizer.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace SharePointCrawler;
+
+/// <summary>
+/// Provides deterministic token counting and splitting utilities used by the
+/// crawler to chunk documents for embedding.  The implementation avoids any
+/// external model dependencies by approximating tokens using a simple
+/// whitespace and punctuation based splitter.
+/// </summary>
+public static class Tokenizer
+{
+    private static readonly Regex TokenRegex = new(@"\w+|[^\w\s]", RegexOptions.Compiled);
+
+    private record TokenSpan(int Start, int Length);
+
+    private static List<TokenSpan> TokenizeInternal(string text)
+    {
+        var matches = TokenRegex.Matches(text);
+        var spans = new List<TokenSpan>(matches.Count);
+        foreach (Match m in matches)
+        {
+            spans.Add(new TokenSpan(m.Index, m.Length));
+        }
+        return spans;
+    }
+
+    /// <summary>
+    /// Counts the approximate number of tokens in the supplied text.
+    /// </summary>
+    public static int CountTokens(string text) => TokenizeInternal(text).Count;
+
+    /// <summary>
+    /// Splits the text into windows based on a target token count and overlap.
+    /// </summary>
+    /// <param name="text">The text to split.</param>
+    /// <param name="target">Approximate tokens per chunk.</param>
+    /// <param name="overlap">Number of overlapping tokens between chunks.</param>
+    /// <returns>A sequence of text slices preserving character boundaries.</returns>
+    public static IEnumerable<(int Start, int Length, string Text)> SmartSplitByTokens(
+        string text, int target = 350, int overlap = 80)
+    {
+        var spans = TokenizeInternal(text);
+        if (spans.Count == 0)
+            yield break;
+
+        var index = 0;
+        while (index < spans.Count)
+        {
+            var end = Math.Min(index + target, spans.Count);
+            var startChar = spans[index].Start;
+            var endSpan = spans[end - 1];
+            var endChar = endSpan.Start + endSpan.Length;
+            yield return (startChar, endChar - startChar, text.Substring(startChar, endChar - startChar));
+
+            if (end == spans.Count)
+                break;
+            index = Math.Max(end - overlap, index + 1);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement local tokenization and heading-aware chunking with metadata
- add CLI options for selective title-based crawls and configurable embedding collection
- document new crawler modes and chunk sizing

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af14cdb0308324b5729854ab75ae20