### PR TITLE
Improve logging and path handling in crawler

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -39,7 +39,8 @@ public static class Program
         }
 
         var siteUrl = args[0];
-        var libraryRelativeUrl = $"{siteUrl}/_api/web/GetFolderByServerRelativeUrl('{args[1]}')?$expand=Folders,Files";
+        var encodedLibraryPath = Uri.EscapeDataString(args[1]);
+        var libraryRelativeUrl = $"{siteUrl}/_api/web/GetFolderByServerRelativeUrl('{encodedLibraryPath}')?$expand=Folders,Files";
         var username = args[2];
         var password = args[3];
         var domain = args.Length > 4 ? args[4] : string.Empty;


### PR DESCRIPTION
## Summary
- log document and folder processing details
- URL-encode library paths to include libraries with spaces
- add fallback for folder paths missing `odata.id`

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f51f891883249da871d2b46f7383