### PR TITLE
Add crawl progress bar and document counting

### DIFF
--- a/ConsoleWindow.cs
+++ b/ConsoleWindow.cs
@@ -25,6 +25,7 @@ public static class ConsoleWindow
 
     private static int _processedCount;
     private static TimeSpan _totalTime = TimeSpan.Zero;
+    private static int _totalDocuments;
 
     /// <summary>
     /// Clears the console and draws the bordered windows.
@@ -79,6 +80,15 @@ public static class ConsoleWindow
 
         _processedCount++;
         _totalTime += elapsed;
+        DrawMetrics();
+    }
+
+    /// <summary>
+    /// Sets the total number of documents to be processed.
+    /// </summary>
+    public static void SetTotalDocuments(int total)
+    {
+        _totalDocuments = total;
         DrawMetrics();
     }
 
@@ -145,8 +155,14 @@ public static class ConsoleWindow
         var avgSeconds = _processedCount > 0 ? _totalTime.TotalSeconds / _processedCount : 0;
         var avgMinutes = avgSeconds / 60.0;
         Console.SetCursorPosition(0, HeaderHeight + PaneHeight * 2);
-        var msg = $"Processed: {_processedCount}  Avg Time: {avgSeconds:F1}s ({avgMinutes:F1}m)";
+        var msg = $"Processed: {_processedCount}/{_totalDocuments}  Avg Time: {avgSeconds:F1}s ({avgMinutes:F1}m)";
         Console.Write(msg.PadRight(Width));
+        double progress = _totalDocuments > 0 ? (double)_processedCount / _totalDocuments : 0;
+        int barWidth = Math.Min(Width - 20, 40);
+        int filled = (int)(barWidth * progress);
+        var bar = "[" + new string('#', filled) + new string('-', barWidth - filled) + $"] {progress * 100:F0}%";
+        Console.SetCursorPosition(0, HeaderHeight + PaneHeight * 2 + 1);
+        Console.Write(bar.PadRight(Width));
     }
 
     /// <summary>

--- a/Program.cs
+++ b/Program.cs
@@ -75,6 +75,8 @@ public static class Program
         ConsoleWindow.Initialize();
 
         using var client = new SharePointClient(siteUrl, credential, allowedTitles,chunkSizeTokens,overlapTokens,collection);
+        var totalDocs = await client.GetTotalDocumentCountAsync(libraryRelativeUrl);
+        ConsoleWindow.SetTotalDocuments(totalDocs);
         await foreach (var doc in client.GetDocumentsAsync(libraryRelativeUrl))
         {
             // Processing feedback is handled by SharePointClient via ConsoleWindow.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This sample project demonstrates how to crawl a SharePoint on‑premises document library using the SharePoint REST API and .NET 8.  Given the server‑relative URL to a library or folder, the crawler traverses the hierarchy, downloads each file and exposes both its binary contents and metadata.  A stubbed method (`SendToExternalApiAsync`) is provided so that you can add your own logic to process or forward the retrieved documents to another API.
 
+The console UI reports progress for the crawl, including a progress bar that reflects the percentage of documents processed.
+
 ## Key REST API concepts
 
 * **Enumerating files and folders** – The crawler makes use of the `GetFolderByServerRelativeUrl` endpoint with the `$expand=Folders,Files` query option to retrieve both files and folders in a single call.  This pattern is recommended when you need to build a directory tree because it returns folder and file information together【697898085085864†L82-L86】.


### PR DESCRIPTION
## Summary
- count total documents before crawl and track processed percentage
- add progress bar to console window with document counts
- initialize progress via Program

## Testing
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68b792e858548324a6e85de57211a19a