### PR TITLE
Expose ingest endpoint setting and enable designer support

### DIFF
--- a/ConsoleWindow.cs
+++ b/ConsoleWindow.cs
@@ -63,7 +63,7 @@ public static class ConsoleWindow
     /// <summary>
     /// Writes an informational message to the current pane.
     /// </summary>
-    public static void Info(string message) => AddLine(_currentLines, message, ConsoleColor.White);
+    public static void Info(string message) => AddLine(_currentLines, message, ConsoleColor.Green);
 
     /// <summary>
     /// Writes a success message to the current pane.

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace SharePointCrawler;
+
+partial class MainForm
+{
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        private TextBox _txtSiteUrl;
+        private TextBox _txtLibraryUrl;
+        private TextBox _txtUsername;
+        private TextBox _txtPassword;
+        private TextBox _txtDomain;
+        private TextBox _txtIngestUrl;
+        private Button _btnStart;
+        private RichTextBox _currentPane;
+        private RichTextBox _previousPane;
+        private Label _metricsLabel;
+        private ProgressBar _progressBar;
+        private TableLayoutPanel tableLayoutPanel1;
+        private Panel outputPanel;
+        private TableLayoutPanel outputLayout;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this._txtSiteUrl = new System.Windows.Forms.TextBox();
+            this._txtLibraryUrl = new System.Windows.Forms.TextBox();
+            this._txtUsername = new System.Windows.Forms.TextBox();
+            this._txtPassword = new System.Windows.Forms.TextBox();
+            this._txtDomain = new System.Windows.Forms.TextBox();
+            this._txtIngestUrl = new System.Windows.Forms.TextBox();
+            this._btnStart = new System.Windows.Forms.Button();
+            this._currentPane = new System.Windows.Forms.RichTextBox();
+            this._previousPane = new System.Windows.Forms.RichTextBox();
+            this._metricsLabel = new System.Windows.Forms.Label();
+            this._progressBar = new System.Windows.Forms.ProgressBar();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.outputPanel = new System.Windows.Forms.Panel();
+            this.outputLayout = new System.Windows.Forms.TableLayoutPanel();
+            this.SuspendLayout();
+            // 
+            // txt boxes
+            // 
+            this._txtSiteUrl.PlaceholderText = "Site URL";
+            this._txtSiteUrl.Width = 300;
+            this._txtLibraryUrl.PlaceholderText = "Library Relative URL";
+            this._txtLibraryUrl.Width = 300;
+            this._txtUsername.PlaceholderText = "Username";
+            this._txtUsername.Width = 150;
+            this._txtPassword.PlaceholderText = "Password";
+            this._txtPassword.UseSystemPasswordChar = true;
+            this._txtPassword.Width = 150;
+            this._txtDomain.PlaceholderText = "Domain";
+            this._txtDomain.Width = 150;
+            this._txtIngestUrl.PlaceholderText = "Ingest Endpoint URL";
+            this._txtIngestUrl.Width = 300;
+            // 
+            // _btnStart
+            // 
+            this._btnStart.Text = "Start";
+            this._btnStart.Width = 80;
+            // 
+            // _currentPane
+            // 
+            this._currentPane.ReadOnly = true;
+            this._currentPane.Width = 700;
+            this._currentPane.Height = 150;
+            this._currentPane.BackColor = Color.Black;
+            this._currentPane.ForeColor = Color.Lime;
+            this._currentPane.Font = new Font("Consolas", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            // 
+            // _previousPane
+            // 
+            this._previousPane.ReadOnly = true;
+            this._previousPane.Width = 700;
+            this._previousPane.Height = 150;
+            this._previousPane.BackColor = Color.Black;
+            this._previousPane.ForeColor = Color.Lime;
+            this._previousPane.Font = new Font("Consolas", 9F, FontStyle.Regular, GraphicsUnit.Point);
+            // 
+            // _metricsLabel
+            // 
+            this._metricsLabel.AutoSize = true;
+            // 
+            // _progressBar
+            // 
+            this._progressBar.Width = 700;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            this.tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            this.tableLayoutPanel1.RowCount = 8;
+            this.tableLayoutPanel1.Dock = DockStyle.Fill;
+            // add controls
+            this.tableLayoutPanel1.Controls.Add(new Label { Text = "Site URL", AutoSize = true }, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this._txtSiteUrl, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(new Label { Text = "Library URL", AutoSize = true }, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this._txtLibraryUrl, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(new Label { Text = "Username", AutoSize = true }, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this._txtUsername, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(new Label { Text = "Password", AutoSize = true }, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this._txtPassword, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(new Label { Text = "Domain", AutoSize = true }, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this._txtDomain, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(new Label { Text = "Ingest URL", AutoSize = true }, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this._txtIngestUrl, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this._btnStart, 1, 6);
+            // 
+            // outputPanel
+            // 
+            this.outputPanel.Dock = DockStyle.Fill;
+            this.tableLayoutPanel1.Controls.Add(this.outputPanel, 0, 7);
+            this.tableLayoutPanel1.SetColumnSpan(this.outputPanel, 2);
+            // 
+            // outputLayout
+            // 
+            this.outputLayout.ColumnCount = 1;
+            this.outputLayout.RowCount = 6;
+            this.outputLayout.Dock = DockStyle.Fill;
+            this.outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            this.outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            this.outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            this.outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            this.outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            this.outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            this.outputLayout.Controls.Add(new Label { Text = "Current Document", AutoSize = true, ForeColor = Color.Blue }, 0, 0);
+            this.outputLayout.Controls.Add(this._currentPane, 0, 1);
+            this.outputLayout.Controls.Add(new Label { Text = "Previous Document", AutoSize = true }, 0, 2);
+            this.outputLayout.Controls.Add(this._previousPane, 0, 3);
+            this.outputLayout.Controls.Add(this._progressBar, 0, 4);
+            this.outputLayout.Controls.Add(this._metricsLabel, 0, 5);
+            this.outputPanel.Controls.Add(this.outputLayout);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new SizeF(7F, 15F);
+            this.AutoScaleMode = AutoScaleMode.Font;
+            this.ClientSize = new Size(750, 650);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Text = "SharePoint Crawler";
+            this.ResumeLayout(false);
+        }
+
+        #endregion
+    }
+}

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -9,65 +9,11 @@ namespace SharePointCrawler;
 
 public partial class MainForm : Form
 {
-    private readonly TextBox _txtSiteUrl = new() { PlaceholderText = "Site URL", Width = 300 };
-    private readonly TextBox _txtLibraryUrl = new() { PlaceholderText = "Library Relative URL", Width = 300 };
-    private readonly TextBox _txtUsername = new() { PlaceholderText = "Username", Width = 150 };
-    private readonly TextBox _txtPassword = new() { PlaceholderText = "Password", UseSystemPasswordChar = true, Width = 150 };
-    private readonly TextBox _txtDomain = new() { PlaceholderText = "Domain", Width = 150 };
-    private readonly Button _btnStart = new() { Text = "Start", Width = 80 };
-
-    private readonly RichTextBox _currentPane = new() { ReadOnly = true, Width = 700, Height = 150 };
-    private readonly RichTextBox _previousPane = new() { ReadOnly = true, Width = 700, Height = 150 };
-    private readonly Label _metricsLabel = new() { AutoSize = true };
-    private readonly ProgressBar _progressBar = new() { Width = 700 };
-
     private SharePointClient? _client;
 
     public MainForm()
     {
-        Text = "SharePoint Crawler";
-        Width = 750;
-        Height = 650;
-        var table = new TableLayoutPanel
-        {
-            Dock = DockStyle.Fill,
-            RowCount = 7,
-            ColumnCount = 2
-        };
-        table.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
-        table.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
-        Controls.Add(table);
-
-        table.Controls.Add(new Label { Text = "Site URL", AutoSize = true }, 0, 0);
-        table.Controls.Add(_txtSiteUrl, 1, 0);
-        table.Controls.Add(new Label { Text = "Library URL", AutoSize = true }, 0, 1);
-        table.Controls.Add(_txtLibraryUrl, 1, 1);
-        table.Controls.Add(new Label { Text = "Username", AutoSize = true }, 0, 2);
-        table.Controls.Add(_txtUsername, 1, 2);
-        table.Controls.Add(new Label { Text = "Password", AutoSize = true }, 0, 3);
-        table.Controls.Add(_txtPassword, 1, 3);
-        table.Controls.Add(new Label { Text = "Domain", AutoSize = true }, 0, 4);
-        table.Controls.Add(_txtDomain, 1, 4);
-        table.Controls.Add(_btnStart, 1, 5);
-
-        var outputPanel = new Panel { Dock = DockStyle.Fill };
-        table.Controls.Add(outputPanel, 0, 6);
-        table.SetColumnSpan(outputPanel, 2);
-
-        var outputLayout = new TableLayoutPanel { Dock = DockStyle.Fill, RowCount = 5, ColumnCount = 1 };
-        outputPanel.Controls.Add(outputLayout);
-        outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        outputLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        outputLayout.Controls.Add(new Label { Text = "Current Document", AutoSize = true, ForeColor= Color.Blue }, 0, 0);
-        outputLayout.Controls.Add(_currentPane, 0, 1);
-        outputLayout.Controls.Add(new Label { Text = "Previous Document", AutoSize = true }, 0, 2);
-        outputLayout.Controls.Add(_previousPane, 0, 3);
-        outputLayout.Controls.Add(_progressBar, 0, 4);
-        outputLayout.Controls.Add(_metricsLabel, 0, 5);
-
+        InitializeComponent();
         _btnStart.Click += BtnStart_Click;
     }
 
@@ -75,7 +21,7 @@ public partial class MainForm : Form
     {
         _btnStart.Enabled = false;
         var credential = new NetworkCredential(_txtUsername.Text, _txtPassword.Text, _txtDomain.Text);
-        _client = new SharePointClient(_txtSiteUrl.Text, credential, new HashSet<string>(), 350, 80, "docs_v2");
+        _client = new SharePointClient(_txtSiteUrl.Text, credential, new HashSet<string>(), 350, 80, "docs_v2", _txtIngestUrl.Text);
         var libraryUrl = $"{_txtSiteUrl.Text}/_api/web/GetFolderByServerRelativeUrl('{_txtLibraryUrl.Text}')?$expand=Folders,Files";
         int total = await _client.CountDocumentsAsync(libraryUrl);
         ConsoleWindow.Initialize(this, total);
@@ -151,7 +97,7 @@ public partial class MainForm : Form
     private static Color ToColor(ConsoleColor color) => color switch
     {
         ConsoleColor.Red => Color.Red,
-        ConsoleColor.Green => Color.Green,
-        _ => Color.White
+        ConsoleColor.Green => Color.Lime,
+        _ => Color.Lime
     };
 }

--- a/SharePointClient.cs
+++ b/SharePointClient.cs
@@ -41,6 +41,7 @@ public class SharePointClient : IDisposable
     private readonly HttpClient _client;
     private readonly string _siteUrl;
     private string _rootUrl = string.Empty;
+    private readonly string _ingestUrl;
     private static readonly Regex PageNumberRegex = new(@"^(page\s*\d+(\s*of\s*\d+)?)|^\d+$", RegexOptions.IgnoreCase);
     private static readonly Regex SignatureRegex = new(@"^(signature|signed|approved by|prepared by).*", RegexOptions.IgnoreCase);
     private static readonly Regex ToCRegex = new(@"table of contents", RegexOptions.IgnoreCase);
@@ -72,7 +73,7 @@ public class SharePointClient : IDisposable
     /// </summary>
     /// <param name="siteUrl">The base URL of the SharePoint site.</param>
     /// <param name="credential">Windows credentials for authentication.</param>
-    public SharePointClient(string siteUrl, NetworkCredential? credential, HashSet<string> allowedTitles, int chunkSizeTokens, int overlapTokens, string collection)
+    public SharePointClient(string siteUrl, NetworkCredential? credential, HashSet<string> allowedTitles, int chunkSizeTokens, int overlapTokens, string collection, string ingestUrl)
     {
         if (string.IsNullOrWhiteSpace(siteUrl))
             throw new ArgumentException("Site URL must be provided", nameof(siteUrl));
@@ -82,6 +83,7 @@ public class SharePointClient : IDisposable
         _chunkSizeTokens = chunkSizeTokens;
         _overlapTokens = overlapTokens;
         _collection = collection;
+        _ingestUrl = ingestUrl;
 
 
         // Trim trailing slashes from the site URL so we don't end up with
@@ -414,12 +416,7 @@ public class SharePointClient : IDisposable
         var sourceUrl = $"{_rootUrl}{doc.Url}"; // or a fixed URL if desired
 
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(30) };
-
-#if DEBUG
-        var url = "http://10.0.0.54:8000/ingest/upload";
-#else
-    var url = "http://adam.amentumspacemissions.com:8000/ingest/upload";
-#endif
+        var url = _ingestUrl;
 
         // Build multipart/form-data
         using var form = new MultipartFormDataContent();


### PR DESCRIPTION
## Summary
- create a designer-friendly `MainForm` with configurable ingest endpoint and terminal-like output panes
- remove compile-time URL selection and accept ingest endpoint via `SharePointClient` constructor
- tint console output and forms to mimic a bash terminal

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c21b0362008324a451d89f79a5f44a