### PR TITLE
Persist text box values

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -15,6 +15,28 @@ public partial class MainForm : Form
     {
         InitializeComponent();
         _btnStart.Click += BtnStart_Click;
+
+        var settings = UserSettings.Load();
+        _txtSiteUrl.Text = settings.SiteUrl ?? string.Empty;
+        _txtLibraryUrl.Text = settings.LibraryUrl ?? string.Empty;
+        _txtUsername.Text = settings.Username ?? string.Empty;
+        _txtPassword.Text = settings.Password ?? string.Empty;
+        _txtDomain.Text = settings.Domain ?? string.Empty;
+        _txtIngestUrl.Text = settings.IngestUrl ?? string.Empty;
+
+        FormClosing += (_, _) =>
+        {
+            var s = new UserSettings
+            {
+                SiteUrl = _txtSiteUrl.Text,
+                LibraryUrl = _txtLibraryUrl.Text,
+                Username = _txtUsername.Text,
+                Password = _txtPassword.Text,
+                Domain = _txtDomain.Text,
+                IngestUrl = _txtIngestUrl.Text
+            };
+            s.Save();
+        };
     }
 
     private async void BtnStart_Click(object? sender, EventArgs e)

--- a/UserSettings.cs
+++ b/UserSettings.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace SharePointCrawler;
+
+internal class UserSettings
+{
+    private static readonly string SettingsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "SharePointCrawler");
+    private static readonly string SettingsPath = Path.Combine(SettingsDir, "settings.json");
+
+    public string? SiteUrl { get; set; }
+    public string? LibraryUrl { get; set; }
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+    public string? Domain { get; set; }
+    public string? IngestUrl { get; set; }
+
+    public static UserSettings Load()
+    {
+        try
+        {
+            if (File.Exists(SettingsPath))
+            {
+                string json = File.ReadAllText(SettingsPath);
+                var settings = JsonSerializer.Deserialize<UserSettings>(json);
+                if (settings != null)
+                {
+                    return settings;
+                }
+            }
+        }
+        catch
+        {
+            // Ignore any errors and return defaults
+        }
+        return new UserSettings();
+    }
+
+    public void Save()
+    {
+        try
+        {
+            Directory.CreateDirectory(SettingsDir);
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            string json = JsonSerializer.Serialize(this, options);
+            File.WriteAllText(SettingsPath, json);
+        }
+        catch
+        {
+            // Ignore any errors
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve text box inputs across runs by loading previously saved values and saving on form close.
- Implement simple JSON-based user settings storage.

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c22f87051483248812c2f081cec072